### PR TITLE
Set a default ZeRO stage in ParallelConfig

### DIFF
--- a/utils/configs.py
+++ b/utils/configs.py
@@ -23,7 +23,7 @@ class OptimizerConfig:
 @chz.chz
 class ParallelConfig:
     data_parallel: int
-    zero_stage: Optional[int]
+    zero_stage: int = 0
 
 
 @chz.chz


### PR DESCRIPTION
## Summary
- default the ZeRO stage in `ParallelConfig` to 0 so configs do not need to specify it explicitly
- ensure experiment configs that omit `zero_stage` (e.g. `exps/gpt2.py`) instantiate without errors

## Testing
- `python - <<'PY'
from utils.configs import ParallelConfig
print(ParallelConfig(data_parallel=1))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e04d676100832996d77715ec889dde